### PR TITLE
Ensure primer sequence field is handled correctly

### DIFF
--- a/bygul/_cli.py
+++ b/bygul/_cli.py
@@ -7,7 +7,7 @@ import pandas as pd
 
 
 @click.group(context_settings={"show_default": True})
-@click.version_option("3.1.0")
+@click.version_option("3.2.0")
 def cli():
     pass
 

--- a/bygul/utils.py
+++ b/bygul/utils.py
@@ -326,16 +326,42 @@ def preprocess_primers(primer_file, reference):
         "strand",
         "primer_seq",
     ]
-    # read the primer bed file
-    primer_bed = pd.read_csv(primer_file, sep="\t",
-                             names=col_names,
-                             comment='#')
-    primer_bed = validate_primer_bed(primer_bed)
-    primer_bed["primer_seq"] = primer_bed.apply(
-        lambda row: extract_sequence(
-            reference, row["ref"], row["start"], row["end"]),
-        axis=1,
+
+    primer_bed = pd.read_csv(
+        primer_file,
+        sep="\t",
+        names=col_names,
+        comment="#",
     )
+
+    primer_bed = validate_primer_bed(primer_bed)
+
+    if (
+        "primer_seq" not in primer_bed.columns
+        or primer_bed["primer_seq"].isna().all()
+        or (primer_bed["primer_seq"].astype(str).str.strip() == "").all()
+    ):
+        warnings.warn(
+            "primer_seq column missing or empty; "
+            "extracting sequences from reference.. "
+            "This is not recommended.",
+            UserWarning,
+        )
+        primer_bed["primer_seq"] = primer_bed.apply(
+            lambda row: extract_sequence(
+                reference,
+                row["ref"],
+                row["start"],
+                row["end"],
+            ),
+            axis=1,
+        )
+    else:
+        neg_strand = primer_bed["strand"] == "-"
+        primer_bed.loc[neg_strand, "primer_seq"] = (
+            primer_bed.loc[neg_strand, "primer_seq"]
+            .apply(lambda seq: str(Seq(seq).reverse_complement()))
+            )
     # split the amplicon name into number and left/right
     primer_bed["amplicon_number"] = primer_bed["left_right"].str.split(
         "_").str[1]

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ description = ("Amplicon read simualtor")
 
 setup(
     name="bygul",
-    version="V3.1.0",
+    version="V3.2.0",
     packages=find_packages(include=['bygul']),
     author="Maryam Ahmadi Jeshvaghane",
     license='BSD 2-Clause',


### PR DESCRIPTION
Bygul, previously extracted all primer sequences from a user-provided reference file regardless of the column existing in the bed file or not. Now, we ensure using the primer sequence field if the file contains it. If not, it throws a warning saying that the sequence is extracted from the reference but this is not recommended.